### PR TITLE
initialize pending pings variable in connect, so that reconnections c…

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -168,6 +168,7 @@ bool PubSubClient::connect(MQTT::Connect &conn) {
     return false;
   }
 
+  pingOutstanding = false;
   nextMsgId = 1;		// Init the next packet id
   lastInActivity = millis();	// Init this so that wait_for() doesn't think we've already timed-out
   keepalive = conn.keepalive();	// Store the keepalive period from this connection


### PR DESCRIPTION
…an occur correctly without disconnecting after each connection once first failure occurs.

(NB: currently used in "loop", but imho, should be reset in connect, otherwise it creates a cyclic disconnect after the first wifi failure/disconnection).

I noticed this after I had a wifi dropout, and each subsequent connect would immediately disconnect.
