### PR TITLE
Fixed comparison of message packet ids

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -133,11 +133,11 @@ bool PubSubClient::_wait_for(MQTT::message_type match_type, uint16_t match_pid) 
     MQTT::Message *msg = _recv_message();
     if (msg != NULL) {
       if (msg->type() == match_type) {
-	uint8_t pid = msg->packet_id();
-	delete msg;
-	if (match_pid)
-	  return pid == match_pid;
-	return true;
+		uint16_t pid = msg->packet_id();
+		delete msg;
+		if (match_pid)
+			return pid == match_pid;
+		return true;
       }
 
       _process_message(msg);


### PR DESCRIPTION
When publishing with QoS 1, publish()  always returned false after first
255 messages. It was due to comparision between uint8 and uint16
variables. (line 136). Now publish with QoS1 works fine even after rollover after 2^16 messages.