### PR TITLE
Library name conflict bug

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=PubSubClient
-version=1.99.1
+name=PubSubClient(ESP8266)
+version=1.99.2
 author=Nick O'Leary, Ian Tester <imroykun@gmail.com>
 maintainer=Ian Tester <imroykun@gmail.com>
 sentence=A library for communicating with MQTT brokers.


### PR DESCRIPTION
PubSubClient is the name of the original knolleary library. 
The knolleary library is present on Arduino Library Manager, so the automatic library update system, that check only the name of a library, think that this is the knolleary library and ask to the user to update it (because the knolleary is at v2.0.3)
If the user accept the update this library is overwritten.

By this name change the Arduino Library Manager know that this is a different library and do not ask the update.