### PR TITLE
Fix: Library remains blocked and PUBCOMP packet

### DIFF
--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -588,7 +588,7 @@ namespace MQTT {
 
   // PublishComp class
   PublishComp::PublishComp(uint16_t pid) :
-    Message(PUBREC)
+    Message(PUBCOMP)
   {
     _packet_id = pid;
   }

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -37,6 +37,7 @@ private:
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
    bool pingOutstanding;
+   bool isSubAckFound;
 
    //! Receive a message from the client
    /*!


### PR DESCRIPTION
**First commit:** Correct the PublishComp object to send a PUBCOMP packet and not a PUBREC packet.

**Second commit:** If there are incoming PUBLISH messages while we wait for a SUBACK, the library remains blocked. 

This case occurs when the client (in persistent session, with a QoS > 0) subscribe to a topic, and the broker sends PUBLISH messages that was not acknowledge by this client (just after the CONNECT). 
The SUBACK message send by the broker is received just after PUBLISH messages, but it is proceeded when the library wait for the acknowledge of PUBLISH messages (PUBREC, PUBCOMP), and so the packet is discarded. 

At first I try to execute the loop method before subscribing to a topic, but in my case I do a subscription just after the connection, so PUBLISH messages are not arrived when I send the SUBSCRIBE message, but they are already sent by the broker.

Tested on a ESP8266-01 and with mosquitto 1.4.10
