### PR TITLE
Fix PublishAck to send variable header with packet id

### DIFF
--- a/examples/ESP8266-OTA/ESP8266-OTA.ino
+++ b/examples/ESP8266-OTA/ESP8266-OTA.ino
@@ -44,7 +44,6 @@ void receive_ota(const MQTT::Publish& pub) {
 
   Serial.setDebugOutput(true);
   if (ESP.updateSketch(*pub.payload_stream(), size, true, false)) {
-    pub.payload_stream()->stop();
     Serial.println("Clearing retained message.");
     client.publish(MQTT::Publish(pub.topic(), "")
                    .set_retain());

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PubSubClient(THKDev)
-version=1.99.2
+version=1.99.3
 author=Nick O'Leary, Ian Tester, ThomasK
 maintainer=ThomasK
 sentence=A library for communicating with MQTT brokers.

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=PubSubClient(imroy)
-version=1.99.1
-author=Nick O'Leary, Ian Tester <imroykun@gmail.com>
-maintainer=Ian Tester <imroykun@gmail.com>
+name=PubSubClient(THKDev)
+version=1.99.2
+author=Nick O'Leary, Ian Tester, ThomasK
+maintainer=ThomasK
 sentence=A library for communicating with MQTT brokers.
 paragraph=Supports MQTT 3.1.1.
 category=Communication
-url=https://github.com/Imroy/pubsubclient
+url=https://github.com/THKDev/pubsubclient
 architectures=*

--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -412,7 +412,7 @@ namespace MQTT {
     _payload_len(strlen_P((PGM_P)payload)), _payload(new uint8_t[_payload_len + 1]),
     _payload_mine(true)
   {
-    strncpy((char*)_payload, (PGM_P)payload, _payload_len);
+    strncpy_P((char*)_payload, (PGM_P)payload, _payload_len);
   }
 
   Publish Publish_P(String topic, PGM_P payload, uint32_t length) {

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -53,6 +53,13 @@ namespace MQTT {
     Reserved,		// Reserved
   };
 
+  //! The Quality of Service (QoS) level is an agreement between sender and receiver of a message regarding the guarantees of delivering a message.  
+  enum Qos {
+      QOS0 = 0,  //! At most once
+      QOS1 = 1,  //! At least once
+      QOS2 = 2   //! Exactly once
+  };
+
 #ifdef _GLIBCXX_FUNCTIONAL
   typedef std::function<bool(Client&)> payload_callback_t;
 #else

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -327,6 +327,9 @@ namespace MQTT {
   //! Response to Publish when qos == 1
   class PublishAck : public Message {
   private:
+    uint32_t variable_header_length(void) const { return sizeof(_packet_id); }
+    void write_variable_header(uint8_t *buf, uint32_t& bufpos) const { write_packet_id(buf, bufpos); }
+
     //! Private constructor from a network buffer
     PublishAck(uint8_t* data, uint32_t length);
 


### PR DESCRIPTION
Patch fixes the acknowledgement of QOS1. Because of missing packet id a server like mosquitto does NOT remove a QOS1 message from queue. QOS1 message is resend every time the client does a reconnect.

Fix has been done according to:
https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718043
