### PR TITLE
this commit fixes #64

### DIFF
--- a/examples/ESP8266-OTA/ESP8266-OTA.ino
+++ b/examples/ESP8266-OTA/ESP8266-OTA.ino
@@ -44,7 +44,6 @@ void receive_ota(const MQTT::Publish& pub) {
 
   Serial.setDebugOutput(true);
   if (ESP.updateSketch(*pub.payload_stream(), size, true, false)) {
-    pub.payload_stream()->stop();
     Serial.println("Clearing retained message.");
     client.publish(MQTT::Publish(pub.topic(), "")
                    .set_retain());


### PR DESCRIPTION
this commit fixes #64  OTA over MQTT

Remove   `pub.payload_stream()->stop();`
Do NOT stop the client connection because the (WiFi) `Client` hold in class `Publish` is NOT ref counted. It is only a pointer. Closing it will count ref to 0 and close the TCP connection.


