### PR TITLE
Fixed numerous compiler warnings

### DIFF
--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -131,6 +131,9 @@ namespace MQTT {
     case SUBSCRIBE:
     case UNSUBSCRIBE:
       buf[bufpos] |= 0x02;
+	  break;
+    default:
+      break;
     }
     bufpos++;
 
@@ -343,6 +346,10 @@ namespace MQTT {
 	  return nullptr;
 
 	break;
+
+	default:
+		break;
+	
       }
     }
 
@@ -486,7 +493,8 @@ namespace MQTT {
   Publish::Publish(String topic, const __FlashStringHelper* payload) :
     Message(PUBLISH),
     _topic(topic),
-    _payload_len(strlen_P((PGM_P)payload)), _payload(new uint8_t[_payload_len + 1]),
+    _payload(new uint8_t[_payload_len + 1]),
+    _payload_len(strlen_P((PGM_P)payload)), 
     _payload_mine(true)
   {
     strncpy_P((char*)_payload, (PGM_P)payload, _payload_len);
@@ -519,8 +527,9 @@ namespace MQTT {
   Publish::Publish(String topic, payload_callback_t pcb, uint32_t length) :
     Message(PUBLISH),
     _topic(topic),
+    _payload(nullptr), 
     _payload_len(length),
-    _payload(nullptr), _payload_mine(false)
+    _payload_mine(false)
   {
     _payload_callback = pcb;
   }
@@ -599,6 +608,7 @@ namespace MQTT {
     case 2:
       return PUBREC;
     }
+    return None;
   }
 
 

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -140,6 +140,9 @@ void PubSubClient::_process_message(MQTT::Message* msg) {
 
   case MQTT::PINGRESP:
     pingOutstanding = false;
+
+    default:
+    	break;
   }
 }
 

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -25,21 +25,21 @@ public:
   typedef void(*callback_t)(const MQTT::Publish&);
 #endif
 
-private:
-   IPAddress server_ip;
-   String server_hostname;
-   uint16_t server_port;
+private:   
    callback_t _callback;
-
    Client &_client;
    MQTT::PacketParser _parser;
-   uint16_t nextMsgId, keepalive;
    uint8_t _max_retries;
+   bool isSubAckFound;
+   IPAddress server_ip;
+   uint16_t server_port;
+   String server_hostname;
+
+   uint16_t nextMsgId, keepalive;
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
    bool pingOutstanding;
-   bool isSubAckFound;
-
+ 
    //! Receive a message from the client
    /*!
      \return Pointer to message object, nullptr if no message has been received


### PR DESCRIPTION
Problems including:

* Missing enumerations in switches (lack of `default` entries)
* Missing return at end of function
* Incorrect initializer list ordering